### PR TITLE
Fix email oauth scope

### DIFF
--- a/packages/caraml-auth-google/caraml_auth/id_token_credentials.py
+++ b/packages/caraml-auth-google/caraml_auth/id_token_credentials.py
@@ -96,7 +96,7 @@ def _load_credentials_from_file(
 
     if credential_type == _AUTHORIZED_USER_TYPE:
         current_credentials = oauth2_credentials.Credentials.from_authorized_user_info(
-            info, scopes=["openid", "email"]
+            info, scopes=["openid", "https://www.googleapis.com/auth/userinfo.email"]
         )
         current_credentials = IDTokenCredentialsAdapter(credentials=current_credentials)
 


### PR DESCRIPTION
## Context
When the Turing and Merlin SDKs are used to authenticate a user with a user account, the warning `Not all requested scopes were granted by the authorization server, missing scopes email.` gets thrown because the scope specified for the email field was stated as `email` instead of `https://www.googleapis.com/auth/userinfo.email` (see https://developers.google.com/identity/protocols/oauth2/scopes#oauth2 for more info).

This PR makes that change to that value in order to stop the warning from showing.