### PR TITLE
Update installation instructions

### DIFF
--- a/packages/caraml-auth-google/README.md
+++ b/packages/caraml-auth-google/README.md
@@ -4,17 +4,15 @@ Utility package containing functions to authenticate users of the Python SDKs of
 
 ## Installation
 
-As this package currently only contains utility functions, and is not released to the PyPI repository, using helper 
-functions contained in this package requires installing/specifying this package as a Git (VCS) dependency:
-
 To install via `pip`:
 ```shell
-pip install git+https://github.com/caraml-dev/caraml-sdk.git@main#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google
+pip install caraml-auth-google
 ```
 
 To specify this in a `requirements.txt` file:
 ```txt
-caraml-auth-google @ git+https://github.com/caraml-dev/caraml-sdk.git@main#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google
+# Other dependencies here
+caraml-auth-google
 ```
 
 ## Unit Tests


### PR DESCRIPTION
## Context
This PR simply updates the existing instructions that are provided to install `caraml-auth-google`. As we have now begun publishing the package to PyPI, there is no longer a need to provide manual instructions to install this package as a Git dependency. Furthermore, the `pip` installation command, `pip install git+https://github.com/caraml-dev/caraml-sdk.git@main#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google` does not actually work and even throws an error if used. 