### PR TITLE
Upgrade google auth version

### DIFF
--- a/packages/caraml-auth-google/requirements.txt
+++ b/packages/caraml-auth-google/requirements.txt
@@ -1,1 +1,1 @@
-google-auth>=2.16.2
+google-auth>=2.17.3


### PR DESCRIPTION
## Context
This PR pins the version of the `google-auth` package in the SDK to `>=2.17.3` as it is the first [release](https://github.com/googleapis/google-auth-library-python/compare/v2.17.2...v2.17.3) which fixes the version of its `urllib3` dependency at below version `2.0`, because it is no longer [compatible](https://github.com/googleapis/google-auth-library-python/pull/1283) with the functions/objects defined in the `google-auth` package.