### PR TITLE
fix: Upgrade google auth version

### DIFF
--- a/packages/caraml-auth-google/requirements.txt
+++ b/packages/caraml-auth-google/requirements.txt
@@ -1,1 +1,1 @@
-google-auth>=2.17.3
+google-auth>=2.18.0


### PR DESCRIPTION
## Context
This PR is meant to fix PR #5, which bumped the `google-auth package` in the SDK to `>=2.17.3`. However, the target version should be `>2.17.3` instead (i.e. `>=2.18.0`): see https://github.com/caraml-dev/caraml-sdk/pull/5#issuecomment-1709771745 for more details.

